### PR TITLE
extend Lodestone to retrieve "private" data

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -129,10 +129,10 @@ class Character < ApplicationRecord
     end
   end
 
-  def self.fetch(id)
-    data = Lodestone.fetch(id)
+  def self.fetch(id, sess_id = nil)
+    data = Lodestone.fetch(id, sess_id)
     data[:achievements_count] = -1 if data[:achievements].empty?
-    profile_data = data.except(:achievements, :mounts, :minions)
+    profile_data = data.except(:achievements, :mounts, :minions, :orchestrions, :spells)
 
     if character = Character.find_by(id: data[:id])
       character.update!(profile_data)
@@ -179,6 +179,14 @@ class Character < ApplicationRecord
     current_ids = CharacterMinion.where(character_id: character.id).pluck(:minion_id)
     minions = data[:minions].reject { |id| current_ids.include?(id) }
     Character.bulk_insert(character.id, CharacterMinion, :minion, minions)
+
+    current_ids = CharacterOrchestrion.where(character_id: character.id).pluck(:orchestrion_id)
+    orchestrions = data[:orchestrions].reject { |id| current_ids.include?(id) }
+    Character.bulk_insert(character.id, CharacterOrchestrion, :orchestrion, orchestrions)
+
+    current_ids = CharacterSpell.where(character_id: character.id).pluck(:spell_id)
+    spells = data[:spells].reject { |id| current_ids.include?(id) }
+    Character.bulk_insert(character.id, CharacterSpell, :spell, spells)
 
     Character.find(character.id)
   end


### PR DESCRIPTION
Adds support for getting blue mage and orchestrion roll data

So, this isn't ready to be merged yet, but I wanted to provide an example of what I had in mind.

I think it would be cool to be able to retrieve "private" data in Lodestone, but I'm wondering if this has already been explored, and I'm just looking for feedback.

I'm not sure if this method is viable (making requests from one domain to another), but possibly you could just have the user paste in the raw html or something from Lodestone (ugly, to be sure, but at least not a manual process).

Also, it would be nice to be able to extract data that isn't in Lodestone as well (emotes, etc.)

Anyway, figured I'd just throw this out there before going down a crazy rabbit hole for nothing :)