### PR TITLE
Fix typo in outfits.rake

### DIFF
--- a/lib/tasks/outfits.rake
+++ b/lib/tasks/outfits.rake
@@ -57,7 +57,7 @@ namespace :outfits do
     puts "Created #{Outfit.count - count} new outfits"
   end
 
-  task check_armoires: :environment do
+  task find_armoires: :environment do
     Outfit.where(armoireable: false).each do |outfit|
       armoire = Armoire.find_by(item_id: outfit.item_ids.first)
       next unless armoire.present?


### PR DESCRIPTION
According to the task list in all.rake, it shoud be named `find_armoires` instead of `check_armoires`.