### PR TITLE
Create limited sources when linked to limited achievements

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -64,6 +64,10 @@ class Source < ApplicationRecord
         set_text_for_relation!(relation)
         self.related_id = relation.id
         self.related_type = type.name_en
+
+        if self.related_type == 'Achievement' && relation.time_limited?
+          self.limited = true
+        end
       else
         remove_relation!
       end


### PR DESCRIPTION
When creating a source for a time limited achievement, automatically set the source to time limited.

Resolves #115 