### PR TITLE
Fix DE translation for Ranked PvP filter

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -221,7 +221,7 @@ de:
     limited: "Zeitexklusive ausschließen"
     outfit: "Als Outfit Lagerbares ausschließen"
     premium: "Premium ausschließen"
-    ranked_pvp: "Ranglisten-PVP"
+    ranked_pvp: "Ranglisten-PvP ausschließen"
     unknown: "Unbekannte ausschließen"
   expand: "Alle aufklappen"
   expansions:


### PR DESCRIPTION
A part of the DE translation was missing.