### PR TITLE
Add character-scoped write API with bearer tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', '~> 1.1.0'
 gem 'rack', '~> 2.2.23'
+gem 'rack-attack'
 gem 'websocket-extensions', '>= 0.1.5'
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-mini-profiler (4.0.1)
@@ -516,6 +518,7 @@ DEPENDENCIES
   paper_trail (~> 16.0.0)
   puma
   rack (~> 2.2.23)
+  rack-attack
   rack-cors (~> 1.1.0)
   rack-mini-profiler
   rails (~> 7.2.3.1)

--- a/WriteApi.md
+++ b/WriteApi.md
@@ -1,0 +1,386 @@
+# FFXIV Collect Write API
+
+This document describes the **plugin write API** that lets an external
+client (such as a Dalamud plugin) push the in-game contents of a
+character to FFXIV Collect.
+
+It complements the existing public read API at `/api` — the read API
+stays unchanged, this is a narrow, opt-in write surface bound to a single
+character.
+
+## Table of contents
+
+1. [Overview](#overview)
+2. [Authentication](#authentication)
+3. [Token lifecycle](#token-lifecycle)
+4. [Writeable collections](#writeable-collections)
+5. [Endpoint reference](#endpoint-reference)
+6. [Idempotency and write semantics](#idempotency-and-write-semantics)
+7. [Errors](#errors)
+8. [Rate limits](#rate-limits)
+9. [Security model](#security-model)
+10. [Example clients](#example-clients)
+
+---
+
+## Overview
+
+```
+┌─────────────┐    Discord OAuth     ┌──────────────────────┐
+│  External   │  (existing)          │   FFXIV Collect Web  │
+│   Client    │ ───── User-Browser ──>                      │
+└─────┬───────┘                      │  Character page →    │
+      │                              │  [Generate API token]│
+      │ Bearer <token>               └──────────┬───────────┘
+      │ POST /api/characters/:id/                │ token shown once
+      │      :collection/owned                   ▼
+      │ { "ids": [1,2,3,...] }              user pastes it
+      ▼                                          │
+┌──────────────────────────────────────┐         │
+│        FFXIV Collect API             │<────────┘
+│  Adds new IDs to the character's     │
+│  owned set for the given collection  │
+└──────────────────────────────────────┘
+```
+
+- Authentication uses **per-character bearer tokens** generated on the
+  FFXIV Collect web UI.
+- The API is **add-only** — collections can grow but never shrink via
+  the write API. Once an item is owned, it stays owned.
+- Writes are **idempotent** — re-sending the same IDs is safe; the
+  server filters them against the current owned set.
+- The token is bound to **one specific character** and authorises writes
+  to **that character only**.
+
+---
+
+## Authentication
+
+Every write request must include a bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+- Tokens are 32 random URL-safe bytes (`SecureRandom.urlsafe_base64(32)`),
+  produced on the server, shown to the user exactly once.
+- Server-side only the **SHA-256 hash** of the token is stored. There is
+  no way to recover a lost token — generate a new one instead.
+- A token is bound to a **single, verified** FFXIV Collect character. If
+  the character loses verification (e.g. it is re-verified by a
+  different Discord account), the token is rejected on the next request.
+- One active token per character. Generating a new one **immediately
+  invalidates the previous one** (hard-delete, no audit trail).
+
+### Required scope
+
+A token's owning character must be **verified** — i.e. the user has
+proven they own that character via the existing Lodestone bio
+verification flow. Unverified characters cannot generate tokens at all.
+
+### Recommended client behaviour
+
+- Send a descriptive `User-Agent` header on every request, e.g.
+  `MyAwesomePlugin/1.2.3 (+https://example.org/plugin)`. The server logs
+  the last UA per token, useful for the user to identify which client
+  last used a token. UA is **not enforced** — a missing UA is not a
+  4xx — but it helps debugging and incident response.
+- Treat the token like a password: keep it in the OS keychain or an
+  encrypted plugin config; never log it.
+
+---
+
+## Token lifecycle
+
+Token operations live on the **web UI**, not the API. They require an
+active web session (Discord-OAuth-authenticated user) who is the
+verified owner of the target character.
+
+### Generate or regenerate
+
+The web user opens `https://ffxivcollect.com/character/<character_id>/api_token`
+and clicks **Generate token** (or **Regenerate token** if one already
+exists). The new token is displayed exactly once; subsequent reloads
+will not show it again. The previous token (if any) is destroyed.
+
+### Revoke
+
+Same page, **Revoke token**. The DB row is deleted; the next API call
+with that token returns `401`.
+
+### Inspect
+
+The same page shows, when a token is active:
+
+- when it was created,
+- when it was last used (`last_used_at`),
+- the `User-Agent` of the last client that used it.
+
+---
+
+## Writeable collections
+
+Collections that are **not** populated from Lodestone — i.e. things a
+Lodestone profile sync does not know about — are writeable via this API:
+
+| Collection      | Path segment   |
+| --------------- | -------------- |
+| Emotes          | `emotes`       |
+| Bardings        | `bardings`     |
+| Hairstyles      | `hairstyles`   |
+| Fashion access. | `fashions`     |
+| Facewear        | `facewear`     |
+| Orchestrion     | `orchestrions` |
+| Framer's kits   | `frames`       |
+| Armoire         | `armoires`     |
+| Glamour outfits | `outfits`      |
+| Triple Triad    | `cards`        |
+
+Everything else — `achievements`, `mounts`, `minions`, etc. — is
+explicitly **rejected** with `400`. Those collections are kept
+authoritative from Lodestone, and accepting writes for them would race
+with the next sync and produce confusing results.
+
+---
+
+## Endpoint reference
+
+### `POST /api/characters/:character_id/:collection/owned`
+
+Add IDs to the character's owned set for the given collection.
+
+**URL parameters**
+
+| Name           | Type    | Notes                                                       |
+| -------------- | ------- | ----------------------------------------------------------- |
+| `character_id` | integer | FFXIV Collect character ID. Must match the token's binding. |
+| `collection`   | string  | One of the [writeable collections](#writeable-collections). |
+
+**Headers**
+
+| Header          | Value                                                |
+| --------------- | ---------------------------------------------------- |
+| `Authorization` | `Bearer <token>`                                     |
+| `Content-Type`  | `application/json`                                   |
+| `User-Agent`    | Recommended (see [Authentication](#authentication)). |
+
+**Request body**
+
+```json
+{
+  "ids": [12, 47, 88, 1024]
+}
+```
+
+- `ids` must be a **non-empty array of integers**.
+- IDs are the canonical FFXIV Collect IDs of the collectables — the
+  same ones returned by the read API.
+- Send as many IDs as you want; one batch is one HTTP request.
+
+**Success response** — `200 OK`
+
+```json
+{
+  "character_id": 5659713,
+  "collection":   "hairstyles",
+  "added":        2,
+  "already_owned": 1,
+  "invalid_ids":  [99999],
+  "total_owned":  117
+}
+```
+
+| Field           | Meaning                                                                |
+| --------------- | ---------------------------------------------------------------------- |
+| `character_id`  | Echo of the path parameter.                                            |
+| `collection`    | Echo of the path parameter.                                            |
+| `added`         | Number of IDs newly added to the owned set.                            |
+| `already_owned` | Number of IDs that were already in the owned set (no-op).              |
+| `invalid_ids`   | IDs the server didn't recognise (don't exist in this collection).      |
+| `total_owned`   | Total size of the character's owned set for this collection after the write. |
+
+---
+
+## Idempotency and write semantics
+
+- **Additive only** — the API never removes IDs from the owned set.
+  Re-running a request with the same IDs is a no-op (`added: 0`,
+  `already_owned: N`). This is intentional: collections in-game are
+  monotonic, you never lose something you owned.
+- **No PUT / no DELETE.** If you need to "fix" a wrongly-marked item,
+  use the web UI; the API doesn't expose that.
+- **Send the full known-owned set if you like** — the server diffs
+  against the existing rows, so over-sending is cheap and safe. Don't
+  feel obliged to track "what did I push last time" client-side.
+- **Order of IDs does not matter.**
+- **Unknown IDs are silently filtered** into `invalid_ids` instead of
+  failing the whole request. This makes the client tolerant to game
+  updates that add new IDs the server hasn't been told about yet.
+
+---
+
+## Errors
+
+All errors return a JSON body of the form:
+
+```json
+{ "status": <code>, "error": "<message>" }
+```
+
+| HTTP | When                                                                                        |
+| ---- | ------------------------------------------------------------------------------------------- |
+| 400  | `ids` missing, not an array, or empty.                                                      |
+| 400  | `:collection` is not in the writeable allowlist (e.g. `mounts`, `achievements`).            |
+| 401  | `Authorization` header missing, malformed, or token doesn't match any record.               |
+| 403  | Token is valid but the URL's `:character_id` doesn't match the token's bound character.     |
+| 403  | Character lost its verification (verified user is now somebody else, or none).              |
+| 429  | Rate limit exceeded. See [Rate limits](#rate-limits). Includes a `Retry-After` header.      |
+| 500  | Internal server error — please open a bug with the request signature (no token in it).      |
+
+---
+
+## Rate limits
+
+Enforced per token by `Rack::Attack`:
+
+| Window     | Limit       |
+| ---------- | ----------- |
+| per minute | **60** writes |
+| per day    | **5 000** writes |
+
+Token **generation** (on the web UI) is throttled per IP at **10 per hour**.
+
+On a `429`, the response carries:
+
+```
+Retry-After: <seconds>
+```
+
+A correctly-implemented client should:
+
+1. Honour `Retry-After`.
+2. Back off exponentially on repeated `429`s.
+3. Never tight-loop — the per-minute window is generous enough that
+   any legitimate sync should fit inside it. If you're hitting limits,
+   batch more aggressively (more IDs per request, fewer requests).
+
+---
+
+## Security model
+
+Threat assumptions and mitigations:
+
+| Threat                                                                       | Mitigation                                                                                              |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Token leak from the user's plugin config                                     | Token only writes to **one specific character**, only to non-Lodestone collections, and is revocable.   |
+| Server compromise leaks the token DB                                         | Only SHA-256 hashes are stored — the raw tokens can't be recovered.                                     |
+| Replay across characters                                                     | The URL `:character_id` must equal the token's bound character (`403` otherwise).                       |
+| Replay after the user re-verifies their character to a different account     | Every write call re-checks `character.verified_user_id == token.user_id` (`403` if mismatched).         |
+| Brute-forcing the token UI                                                   | Per-IP throttle of 10/hour on token generation.                                                         |
+| Brute-forcing tokens via the API                                             | 256-bit entropy plus per-token rate limit — exhausting the space is infeasible.                         |
+| Man-in-the-middle                                                            | Production runs TLS only. Don't use this API over plain HTTP outside local dev.                         |
+| Plugin pushing items the user never owned                                    | This is a trust decision — the user opted in by installing the plugin. The owned set can only grow, so the user can audit it via the read API and revoke if surprised. |
+
+What the API **cannot** do:
+
+- Read or modify any character other than the one the token is bound to.
+- Touch Lodestone-driven collections (mounts, minions, achievements, etc).
+- Modify any web-only state (profile privacy, account settings, etc).
+- Delete items from the owned set.
+
+---
+
+## Example clients
+
+### curl
+
+```sh
+curl -X POST 'https://ffxivcollect.com/api/characters/5659713/hairstyles/owned' \
+     -H 'Authorization: Bearer pAsVcRORRRYBXl_IeS2aZdlEhuJC3zocXKpPYvxoO_A' \
+     -H 'Content-Type: application/json' \
+     -H 'User-Agent: MyPlugin/1.0.0' \
+     -d '{"ids":[573]}'
+```
+
+### C# (Dalamud-style)
+
+```csharp
+using var http = new HttpClient();
+http.DefaultRequestHeaders.UserAgent.ParseAdd("MyPlugin/1.0.0");
+http.DefaultRequestHeaders.Authorization =
+    new AuthenticationHeaderValue("Bearer", token);
+
+var payload = JsonSerializer.Serialize(new { ids = ownedHairstyleIds });
+using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+
+var response = await http.PostAsync(
+    $"https://ffxivcollect.com/api/characters/{characterId}/hairstyles/owned",
+    content);
+
+// Honour Retry-After on 429
+if ((int)response.StatusCode == 429 &&
+    response.Headers.RetryAfter?.Delta is { } delay)
+{
+    await Task.Delay(delay);
+    // ... retry
+}
+
+response.EnsureSuccessStatusCode();
+var result = await response.Content.ReadFromJsonAsync<OwnedResult>();
+```
+
+### Python
+
+```python
+import requests
+
+resp = requests.post(
+    f"https://ffxivcollect.com/api/characters/{character_id}/emotes/owned",
+    json={"ids": emote_ids},
+    headers={
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "my-script/0.1",
+    },
+    timeout=15,
+)
+resp.raise_for_status()
+print(resp.json())
+```
+
+---
+
+## FAQ
+
+**Q: Can I get a list of IDs the user already owns via this API?**
+A: Use the existing public read endpoint
+`GET /api/characters/:id/:collection/owned` — it returns the canonical
+owned set and is unaffected by this API. The write API only **adds**;
+the read API is your source of truth.
+
+**Q: What if my plugin pushes an item that's later removed from the
+game?**
+A: The server filters against the current collectable table. If the ID
+no longer exists, it ends up in `invalid_ids` and is not added. The
+existing owned rows aren't pruned by this endpoint.
+
+**Q: Can two plugins share one token?**
+A: Technically yes — the server doesn't care. But the rate limit is
+**per token**, so they will compete for the same quota. Practically,
+one token per plugin per character keeps audit and rate-limit blame
+clean. Generating a new token in one plugin will invalidate the
+shared token, breaking the other.
+
+**Q: Can the user generate one token that covers all their characters?**
+A: No. Each character has its own token. This is a security feature —
+a plugin can only ever affect the character the user explicitly opted
+in for.
+
+**Q: Is there a way to delete an ID from the owned set via the API?**
+A: No, by design. Collections in-game are monotonic. If you need to
+manually correct a wrongly-tracked item, use the web UI.
+
+**Q: Where do I report a bug?**
+A: Open an issue in the FFXIV Collect GitHub repository. Include the
+endpoint, the request body (with `ids` truncated if long), the HTTP
+status and response body, and your User-Agent. **Never paste your
+token.**

--- a/WriteApi.md
+++ b/WriteApi.md
@@ -1,8 +1,7 @@
 # FFXIV Collect Write API
 
-This document describes the **plugin write API** that lets an external
-client (such as a Dalamud plugin) push the in-game contents of a
-character to FFXIV Collect.
+This document describes the **write API** that lets an external client
+push the in-game contents of a character to FFXIV Collect.
 
 It complements the existing public read API at `/api` — the read API
 stays unchanged, this is a narrow, opt-in write surface bound to a single
@@ -81,12 +80,12 @@ verification flow. Unverified characters cannot generate tokens at all.
 ### Recommended client behaviour
 
 - Send a descriptive `User-Agent` header on every request, e.g.
-  `MyAwesomePlugin/1.2.3 (+https://example.org/plugin)`. The server logs
-  the last UA per token, useful for the user to identify which client
-  last used a token. UA is **not enforced** — a missing UA is not a
-  4xx — but it helps debugging and incident response.
+  `MyClient/1.2.3 (+https://example.org/myclient)`. The server logs the
+  last UA per token, useful for the user to identify which client last
+  used a token. UA is **not enforced** — a missing UA is not a 4xx — but
+  it helps debugging and incident response.
 - Treat the token like a password: keep it in the OS keychain or an
-  encrypted plugin config; never log it.
+  encrypted client configuration; never log it.
 
 ---
 
@@ -272,14 +271,14 @@ Threat assumptions and mitigations:
 
 | Threat                                                                       | Mitigation                                                                                              |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Token leak from the user's plugin config                                     | Token only writes to **one specific character**, only to non-Lodestone collections, and is revocable.   |
+| Token leak from the user's client configuration                              | Token only writes to **one specific character**, only to non-Lodestone collections, and is revocable.   |
 | Server compromise leaks the token DB                                         | Only SHA-256 hashes are stored — the raw tokens can't be recovered.                                     |
 | Replay across characters                                                     | The URL `:character_id` must equal the token's bound character (`403` otherwise).                       |
 | Replay after the user re-verifies their character to a different account     | Every write call re-checks `character.verified_user_id == token.user_id` (`403` if mismatched).         |
 | Brute-forcing the token UI                                                   | Per-IP throttle of 10/hour on token generation.                                                         |
 | Brute-forcing tokens via the API                                             | 256-bit entropy plus per-token rate limit — exhausting the space is infeasible.                         |
 | Man-in-the-middle                                                            | Production runs TLS only. Don't use this API over plain HTTP outside local dev.                         |
-| Plugin pushing items the user never owned                                    | This is a trust decision — the user opted in by installing the plugin. The owned set can only grow, so the user can audit it via the read API and revoke if surprised. |
+| Client pushing items the user never owned                                    | This is a trust decision — the user opted in by installing the client. The owned set can only grow, so the user can audit it via the read API and revoke if surprised. |
 
 What the API **cannot** do:
 
@@ -298,15 +297,15 @@ What the API **cannot** do:
 curl -X POST 'https://ffxivcollect.com/api/characters/5659713/hairstyles/owned' \
      -H 'Authorization: Bearer pAsVcRORRRYBXl_IeS2aZdlEhuJC3zocXKpPYvxoO_A' \
      -H 'Content-Type: application/json' \
-     -H 'User-Agent: MyPlugin/1.0.0' \
+     -H 'User-Agent: MyClient/1.0.0' \
      -d '{"ids":[573]}'
 ```
 
-### C# (Dalamud-style)
+### C# (HttpClient)
 
 ```csharp
 using var http = new HttpClient();
-http.DefaultRequestHeaders.UserAgent.ParseAdd("MyPlugin/1.0.0");
+http.DefaultRequestHeaders.UserAgent.ParseAdd("MyClient/1.0.0");
 http.DefaultRequestHeaders.Authorization =
     new AuthenticationHeaderValue("Bearer", token);
 
@@ -357,22 +356,22 @@ A: Use the existing public read endpoint
 owned set and is unaffected by this API. The write API only **adds**;
 the read API is your source of truth.
 
-**Q: What if my plugin pushes an item that's later removed from the
+**Q: What if my client pushes an item that's later removed from the
 game?**
 A: The server filters against the current collectable table. If the ID
 no longer exists, it ends up in `invalid_ids` and is not added. The
 existing owned rows aren't pruned by this endpoint.
 
-**Q: Can two plugins share one token?**
+**Q: Can two clients share one token?**
 A: Technically yes — the server doesn't care. But the rate limit is
 **per token**, so they will compete for the same quota. Practically,
-one token per plugin per character keeps audit and rate-limit blame
-clean. Generating a new token in one plugin will invalidate the
+one token per client per character keeps audit and rate-limit blame
+clean. Generating a new token in one client will invalidate the
 shared token, breaking the other.
 
 **Q: Can the user generate one token that covers all their characters?**
 A: No. Each character has its own token. This is a security feature —
-a plugin can only ever affect the character the user explicitly opted
+a client can only ever affect the character the user explicitly opted
 in for.
 
 **Q: Is there a way to delete an ID from the owned set via the API?**

--- a/app/assets/javascripts/verification.coffee
+++ b/app/assets/javascripts/verification.coffee
@@ -1,3 +1,3 @@
 $ ->
-  return unless $('#verification').length
+  return unless $('#verification').length or $('#api-token').length
   new Clipboard('.clipboard')

--- a/app/controllers/api/owned_controller.rb
+++ b/app/controllers/api/owned_controller.rb
@@ -1,0 +1,50 @@
+class Api::OwnedController < ApiController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :set_owned
+  before_action :authenticate_api_token!
+
+  # POST /api/characters/:character_id/:collection/owned
+  def create
+    unless @token
+      return render json: { status: 401, error: 'Missing or invalid token' }, status: :unauthorized
+    end
+
+    if @token.character_id != params[:character_id].to_i
+      return render json: { status: 403, error: 'Token does not match character' }, status: :forbidden
+    end
+
+    unless @token.character.verified_user?(@token.user)
+      return render json: { status: 403, error: 'Character is no longer verified for this user' }, status: :forbidden
+    end
+
+    unless Api::OwnedWriter.writeable?(params[:collection])
+      return render json: { status: 400, error: 'Collection is not writeable via API' }, status: :bad_request
+    end
+
+    ids = params[:ids]
+
+    unless ids.is_a?(Array) && ids.any?
+      return render json: { status: 400, error: 'ids must be a non-empty array of integers' }, status: :bad_request
+    end
+
+    result = Api::OwnedWriter.new(@token.character, params[:collection], ids).call
+    @token.touch_usage!(request.user_agent)
+
+    render json: {
+      character_id:  @token.character_id,
+      collection:    params[:collection],
+      added:         result.added,
+      already_owned: result.already_owned,
+      invalid_ids:   result.invalid_ids,
+      total_owned:   result.total_owned
+    }
+  end
+
+  private
+
+  def authenticate_api_token!
+    header = request.headers['Authorization']
+    raw    = header&.match(/\ABearer\s+(.+)\z/)&.captures&.first
+    @token = CharacterApiToken.authenticate(raw)
+  end
+end

--- a/app/controllers/character_api_tokens_controller.rb
+++ b/app/controllers/character_api_tokens_controller.rb
@@ -1,0 +1,41 @@
+class CharacterApiTokensController < ApplicationController
+  before_action :verify_signed_in!
+  before_action :set_character
+  before_action :verify_owner!
+
+  def show
+    @api_token = @character.api_token
+    @plaintext_token = flash[:plaintext_token]
+  end
+
+  def create
+    @character.api_token&.destroy
+    api_token = @character.create_api_token!(user: current_user)
+    flash[:plaintext_token] = api_token.plaintext
+    flash[:success] = 'A new API token has been generated. Copy it now — it will only be shown once.'
+    redirect_to character_api_token_path(character_id: @character.id)
+  end
+
+  def destroy
+    @character.api_token&.destroy
+    flash[:success] = 'API token revoked.'
+    redirect_to character_api_token_path(character_id: @character.id)
+  end
+
+  private
+
+  def set_character
+    @character = Character.find_by(id: params[:character_id])
+    return if @character.present?
+
+    flash[:error] = 'Character not found.'
+    redirect_to root_path
+  end
+
+  def verify_owner!
+    unless @character.verified_user?(current_user)
+      flash[:error] = 'You must be the verified owner of this character to manage its API token.'
+      redirect_to character_path(@character)
+    end
+  end
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -60,6 +60,8 @@ class Character < ApplicationRecord
   belongs_to :verified_user, class_name: 'User', required: false
   belongs_to :free_company, required: false
 
+  has_one :api_token, class_name: 'CharacterApiToken', dependent: :destroy
+
   has_many :group_memberships
   has_many :groups, through: :group_memberships
 

--- a/app/models/character_api_token.rb
+++ b/app/models/character_api_token.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: character_api_tokens
+#
+#  id              :bigint(8)        not null, primary key
+#  character_id    :integer          not null
+#  user_id         :integer          not null
+#  token_hash      :string(64)       not null
+#  last_used_at    :datetime
+#  last_user_agent :string(255)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+class CharacterApiToken < ApplicationRecord
+  belongs_to :character
+  belongs_to :user
+
+  attr_reader :plaintext
+
+  before_create :generate_token
+
+  def self.authenticate(raw_token)
+    return nil if raw_token.blank?
+    find_by(token_hash: Digest::SHA256.hexdigest(raw_token))
+  end
+
+  def touch_usage!(user_agent)
+    update_columns(last_used_at: Time.current,
+                   last_user_agent: user_agent.to_s.first(255))
+  end
+
+  private
+
+  def generate_token
+    @plaintext = SecureRandom.urlsafe_base64(32)
+    self.token_hash = Digest::SHA256.hexdigest(@plaintext)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   has_many :user_characters
   has_many :characters, through: :user_characters
   has_many :verified_characters, -> (user) { where(verified_user: user) }, through: :user_characters, source: :character
+  has_many :character_api_tokens, dependent: :destroy
   has_many :modifications, class_name: 'PaperTrail::Version', foreign_key: :whodunnit
   has_many :owned_groups, class_name: 'Group', foreign_key: :owner_id
   has_many :decks, primary_key: :uid, foreign_key: :user_uid

--- a/app/services/api/owned_writer.rb
+++ b/app/services/api/owned_writer.rb
@@ -1,0 +1,40 @@
+module Api
+  class OwnedWriter
+    WRITEABLE_COLLECTIONS = %w(emotes bardings hairstyles fashions facewear
+                               orchestrions frames armoires outfits cards).freeze
+
+    Result = Struct.new(:added, :already_owned, :invalid_ids, :total_owned, keyword_init: true)
+
+    def self.writeable?(collection)
+      WRITEABLE_COLLECTIONS.include?(collection.to_s)
+    end
+
+    def initialize(character, collection, ids)
+      @character  = character
+      @collection = collection.to_s
+      @ids        = Array(ids).map { |id| Integer(id) rescue nil }.compact.uniq
+    end
+
+    def call
+      singular   = @collection.singularize
+      model      = @collection.classify.constantize
+      join_model = "Character#{model.name}".constantize
+
+      valid_ids = model.where(id: @ids).pluck(:id)
+      invalid   = @ids - valid_ids
+      owned_ids = @character.send("#{singular}_ids")
+      new_ids   = valid_ids - owned_ids
+
+      if new_ids.any?
+        Character.bulk_insert(@character.id, join_model, singular.to_sym, new_ids)
+      end
+
+      Result.new(
+        added:         new_ids.size,
+        already_owned: (valid_ids - new_ids).size,
+        invalid_ids:   invalid,
+        total_owned:   owned_ids.size + new_ids.size
+      )
+    end
+  end
+end

--- a/app/views/character_api_tokens/show.html.erb
+++ b/app/views/character_api_tokens/show.html.erb
@@ -1,0 +1,75 @@
+<% title("#{@character.name} (#{@character.server}) — API Token") %>
+
+<div class="row">
+  <div class="col-12 col-xl-8 offset-xl-2">
+    <div class="card shadow">
+      <div class="card-header d-flex justify-content-between align-items-center py-2">
+        <h5 class="card-title mr-2">API Token — <%= @character.name %></h5>
+        <%= link_to fa_icon('arrow-left', text: 'Back to profile'),
+          character_path(@character), class: 'btn btn-secondary btn-sm' %>
+      </div>
+      <div class="card-body">
+        <p>
+          API tokens let an external client push owned collection IDs to FFXIV
+          Collect on behalf of this character. The token
+          authorises writes to <strong>this character only</strong> and only for the
+          collections that aren't synced from Lodestone (emotes, bardings, hairstyles,
+          fashions, facewear, orchestrions, frames, armoires, outfits, cards).
+        </p>
+
+        <% if @plaintext_token.present? %>
+          <div class="alert alert-warning">
+            <strong>This is the only time the token will be shown.</strong>
+            Copy it now and paste it into the plugin. If you lose it, generate a new
+            one — the old one will stop working.
+          </div>
+          <pre id="api-token" class="p-3 bg-light"><%= @plaintext_token %></pre>
+          <div class="d-flex justify-content-end mb-3">
+            <%= button_tag fa_icon('copy', text: t('clipboard')), class: 'btn btn-secondary btn-sm clipboard mt-0',
+              data: { clipboard_action: 'copy', clipboard_target: '#api-token' } %>
+          </div>
+        <% end %>
+
+        <hr>
+
+        <% if @api_token.present? && @plaintext_token.blank? %>
+          <p>
+            <strong>Token status:</strong> active.<br>
+            Created: <%= @api_token.created_at.strftime('%Y-%m-%d %H:%M') %><br>
+            Last used: <%= @api_token.last_used_at ? @api_token.last_used_at.strftime('%Y-%m-%d %H:%M') : 'never' %><br>
+            <% if @api_token.last_user_agent.present? %>
+              Last client: <code><%= @api_token.last_user_agent %></code>
+            <% end %>
+          </p>
+        <% elsif @plaintext_token.blank? %>
+          <p>No active API token for this character.</p>
+        <% end %>
+
+        <div class="d-flex justify-content-between">
+          <%= button_to fa_icon('key', text: @api_token.present? && @plaintext_token.blank? ? 'Regenerate token' : 'Generate token'),
+            character_api_token_path(character_id: @character.id),
+            method: :post,
+            class: 'btn btn-primary',
+            data: { confirm: @api_token.present? && @plaintext_token.blank? ? 'Regenerating will invalidate your current token. Continue?' : nil } %>
+
+          <% if @api_token.present? %>
+            <%= button_to fa_icon('times', text: 'Revoke token'),
+              character_api_token_path(character_id: @character.id),
+              method: :delete,
+              class: 'btn btn-danger',
+              data: { confirm: 'This will invalidate the current token. Continue?' } %>
+          <% end %>
+        </div>
+
+        <hr>
+
+        <h6>Plugin endpoint</h6>
+        <pre class="p-2 bg-light"><code>POST /api/characters/<%= @character.id %>/&lt;collection&gt;/owned
+Authorization: Bearer &lt;your token&gt;
+Content-Type: application/json
+
+{ "ids": [1, 2, 3] }</code></pre>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/character_api_tokens/show.html.erb
+++ b/app/views/character_api_tokens/show.html.erb
@@ -20,7 +20,7 @@
         <% if @plaintext_token.present? %>
           <div class="alert alert-warning">
             <strong>This is the only time the token will be shown.</strong>
-            Copy it now and paste it into the plugin. If you lose it, generate a new
+            Copy it now and paste it into your client. If you lose it, generate a new
             one — the old one will stop working.
           </div>
           <pre id="api-token" class="p-3 bg-light"><%= @plaintext_token %></pre>
@@ -63,7 +63,7 @@
 
         <hr>
 
-        <h6>Plugin endpoint</h6>
+        <h6>Endpoint</h6>
         <pre class="p-2 bg-light"><code>POST /api/characters/<%= @character.id %>/&lt;collection&gt;/owned
 Authorization: Bearer &lt;your token&gt;
 Content-Type: application/json

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -22,6 +22,12 @@
 
           <%= link_to far_icon('chart-bar', text: t('characters.statistics')),
             stats_rarity_character_path(@profile), class: 'btn btn-success btn-sm' %>
+
+          <% if @profile.verified_user?(current_user) %>
+            <%= link_to fa_icon('key', text: 'API Token'),
+              character_api_token_path(character_id: @profile.id),
+              class: 'btn btn-info btn-sm' %>
+          <% end %>
         </div>
       </div>
       <div class="card-body">

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,10 +50,12 @@ module FfxivCollect
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
-        resource '/api/*', headers: :any, methods: [:get, :options]
+        resource '/api/*', headers: :any, methods: [:get, :post, :options]
         resource '/discord/interactions', headers: :any, methods: [:post]
       end
     end
+
+    config.middleware.use Rack::Attack
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,5 @@
 class Rack::Attack
-  ### Throttle the plugin write API per bearer token ###
+  ### Throttle the write API per bearer token ###
   throttle('api_owned_writes/token', limit: 60, period: 1.minute) do |req|
     if req.post? && req.path =~ %r{\A/api/characters/\d+/[^/]+/owned\z}
       token = req.env['HTTP_AUTHORIZATION'].to_s[/\ABearer\s+(.+)\z/, 1]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,28 @@
+class Rack::Attack
+  ### Throttle the plugin write API per bearer token ###
+  throttle('api_owned_writes/token', limit: 60, period: 1.minute) do |req|
+    if req.post? && req.path =~ %r{\A/api/characters/\d+/[^/]+/owned\z}
+      token = req.env['HTTP_AUTHORIZATION'].to_s[/\ABearer\s+(.+)\z/, 1]
+      Digest::SHA256.hexdigest(token) if token.present?
+    end
+  end
+
+  throttle('api_owned_writes/token/day', limit: 5_000, period: 1.day) do |req|
+    if req.post? && req.path =~ %r{\A/api/characters/\d+/[^/]+/owned\z}
+      token = req.env['HTTP_AUTHORIZATION'].to_s[/\ABearer\s+(.+)\z/, 1]
+      Digest::SHA256.hexdigest(token) if token.present?
+    end
+  end
+
+  ### Throttle token generation per IP (anti-bruteforce of the web UI) ###
+  throttle('api_token_generation/ip', limit: 10, period: 1.hour) do |req|
+    req.ip if req.post? && req.path =~ %r{\A/character/\d+/api_token\z}
+  end
+
+  self.throttled_responder = lambda do |request|
+    retry_after = (request.env['rack.attack.match_data'] || {})[:period]
+    [429,
+     { 'Content-Type' => 'application/json', 'Retry-After' => retry_after.to_s },
+     [{ status: 429, error: 'Too many requests' }.to_json]]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,10 +185,14 @@ Rails.application.routes.draw do
   delete 'character/forget', to: 'characters#forget', as: :forget_character
   delete 'character/unpeek', to: 'characters#unpeek', as: :unpeek_character
 
+  resource :character_api_token, path: 'character/:character_id/api_token',
+                                 only: [:show, :create, :destroy]
+
   namespace :api do
     resources :characters, only: :show do
       get ':collection/owned', action: :owned, as: :owned
       get ':collection/missing', action: :missing, as: :missing
+      post ':collection/owned', to: 'owned#create'
     end
 
     resources :users, only: :show do

--- a/db/migrate/20260524000001_create_character_api_tokens.rb
+++ b/db/migrate/20260524000001_create_character_api_tokens.rb
@@ -1,0 +1,17 @@
+class CreateCharacterApiTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :character_api_tokens do |t|
+      t.integer :character_id, null: false
+      t.integer :user_id, null: false
+      t.string :token_hash, null: false, limit: 64
+      t.datetime :last_used_at
+      t.string :last_user_agent, limit: 255
+
+      t.timestamps
+    end
+
+    add_index :character_api_tokens, :character_id, unique: true
+    add_index :character_api_tokens, :user_id
+    add_index :character_api_tokens, :token_hash, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_29_015627) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_24_000001) do
   create_table "achievement_categories", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
     t.string "name_en", null: false
     t.string "name_de", null: false
@@ -215,6 +215,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_29_015627) do
     t.index ["achievement_id"], name: "index_character_achievements_on_achievement_id"
     t.index ["character_id", "achievement_id"], name: "index_character_achievements_on_character_id_and_achievement_id", unique: true
     t.index ["character_id"], name: "index_character_achievements_on_character_id"
+  end
+
+  create_table "character_api_tokens", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|
+    t.integer "character_id", null: false
+    t.integer "user_id", null: false
+    t.string "token_hash", limit: 64, null: false
+    t.datetime "last_used_at"
+    t.string "last_user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["character_id"], name: "index_character_api_tokens_on_character_id", unique: true
+    t.index ["token_hash"], name: "index_character_api_tokens_on_token_hash", unique: true
+    t.index ["user_id"], name: "index_character_api_tokens_on_user_id"
   end
 
   create_table "character_armoires", charset: "utf8", collation: "utf8_general_ci", force: :cascade do |t|


### PR DESCRIPTION
# Add character-scoped write API with bearer tokens

Proposed implementation for [skyborn-industries/ffxiv-collect#119](https://github.com/skyborn-industries/ffxiv-collect/issues/119).

## Summary

Adds a narrow, opt-in write surface so an external client can push the in-game contents of a single character to FFXIV Collect. The existing public read API at `/api/*` is untouched — this is a separate, authenticated endpoint:

```
POST /api/characters/:character_id/:collection/owned
Authorization: Bearer <character-scoped token>
Content-Type: application/json

{ "ids": [1, 2, 3, ...] }
```

Tokens are generated by the verified character owner from the web UI and are scoped to that single character. Writes are additive only — collections never shrink via this API — and idempotent.

The full API surface (auth, lifecycle, request/response shape, idempotency rules, error codes, rate limits, security model, example clients) is documented in [`WriteApi.md`](./WriteApi.md).

## What's new

### New endpoint
- `Api::OwnedController#create` (`app/controllers/api/owned_controller.rb`) — authenticates the bearer token, re-checks character verification on every request, validates the collection allowlist, and delegates to the writer service.
- `Api::OwnedWriter` (`app/services/api/owned_writer.rb`) — filters submitted IDs against the model, subtracts the character's existing owned set, and bulk-inserts only the new ones. Returns `{ added, already_owned, invalid_ids, total_owned }`.

### Allowlisted collections
Writes are restricted to collections Lodestone does not expose, where an external client is the only practical data source:
`emotes`, `bardings`, `hairstyles`, `fashions`, `facewear`, `orchestrions`, `frames`, `armoires`, `outfits`, `cards`.

Read-only collections (achievements, mounts, minions, …) cannot be written via this API.

### Token management (web UI)
- New `CharacterApiToken` model with a `token_hash` (SHA256 of the plaintext token) and `last_used_at` / `last_user_agent` for audit.
- `CharacterApiTokensController` provides `show` / `create` / `destroy` actions on the character page; only the verified owner sees them.
- The plaintext token is rendered exactly once in a flash; only the hash is persisted, so a leaked DB does not yield usable tokens.
- New migration `20260524000001_create_character_api_tokens` (uniqueness on `character_id` and `token_hash`).

### Rate limiting
Added `config/initializers/rack_attack.rb`:
- **60 writes / token / minute** and **5,000 writes / token / day** on the owned endpoint.
- **10 token-generation POSTs / IP / hour** on the web UI route (anti-bruteforce of the create action).
- Throttled responses return JSON `{ status: 429, error: "Too many requests" }` with `Retry-After`.

### Documentation
- `WriteApi.md` — full external-developer reference (auth flow, token lifecycle, endpoint reference, idempotency, errors, rate limits, security model, example curl / C# / Python clients).

## Security highlights

- **Tokens are character-scoped.** A token for character A cannot write to character B — the controller hard-fails with 403 if `token.character_id != params[:character_id]`.
- **Verification is rechecked on every write.** Losing Lodestone verification (e.g. the character is re-verified by a different account) invalidates the token immediately on the next request, without needing an explicit revocation.
- **Tokens are hashed at rest.** Only `SHA256(token)` is stored; the plaintext is shown to the user once and never persisted.
- **Add-only semantics.** The API can grow a character's owned set but cannot shrink it — a compromised token cannot wipe a collection.
- **Allowlist, not blocklist.** Writeable collections are explicitly enumerated; new models default to read-only.
- **Throttled.** Per-token and per-IP limits keep abuse cheap to detect and bounded in damage.

## Non-goals / out of scope

- No bulk multi-character write — one token, one character, by design.
- No delete semantics — to remove an item, the user uses the existing web UI.
- No write access to collections Lodestone already exposes (achievements, mounts, minions, etc.) — the read API + Lodestone sync remain the source of truth there.
- No OAuth / third-party app registration — tokens are pasted directly by the user into their client.

## Files changed

```
WriteApi.md                                              | 386 ++++++++
app/controllers/api/owned_controller.rb                  |  50 +++
app/controllers/character_api_tokens_controller.rb       |  41 +++
app/models/character_api_token.rb                        |  39 +++
app/services/api/owned_writer.rb                         |  40 +++
app/views/character_api_tokens/show.html.erb             |  75 +++
app/views/characters/show.html.erb                       |   6 +
app/models/character.rb                                  |   2 +
app/models/user.rb                                       |   1 +
config/application.rb                                    |   4 +-
config/initializers/rack_attack.rb                       |  28 +
config/routes.rb                                         |   4 +
db/migrate/20260524000001_create_character_api_tokens.rb |  17 +
db/schema.rb                                             |  15 +-
Gemfile                                                  |   1 +
Gemfile.lock                                             |   3 +
app/assets/javascripts/verification.coffee               |   2 +-
```

## Test plan

- [ ] **Migration**: `bin/rake db:migrate` creates `character_api_tokens` with unique indexes on `character_id` and `token_hash`
- [ ] **Token generation**: as a verified owner, visit the character's API token page, generate a token — plaintext is shown exactly once
- [ ] **Re-generation**: generating a new token destroys the previous one (1:1 character ↔ token)
- [ ] **Authorization (happy path)**: `POST /api/characters/:id/emotes/owned` with `Authorization: Bearer <token>` adds new IDs and returns the expected counts
- [ ] **Idempotency**: re-posting the same IDs returns `added: 0`, `already_owned: N` and does not duplicate rows
- [ ] **Invalid IDs**: posting IDs that do not exist returns them under `invalid_ids` and adds nothing
- [ ] **Cross-character refusal**: a token for character A used against `/api/characters/<B>/.../owned` returns 403
- [ ] **Verification revoked**: clearing the character's verification on the web UI causes the next write to return 403 with the "no longer verified" message
- [ ] **Disallowed collection**: `POST /api/characters/:id/achievements/owned` returns 400 (not in the writeable allowlist)
- [ ] **Rate limit**: 61 writes within a minute from the same token returns 429 with `Retry-After`
- [ ] **Token revoke**: deleting the token in the web UI makes subsequent writes return 401
- [ ] **Last-used tracking**: a successful write updates `last_used_at` and `last_user_agent` on the token row
